### PR TITLE
Don't fail when reopening already open file

### DIFF
--- a/ConfigDumpFileIO/ConfigDumpFileIO.cs
+++ b/ConfigDumpFileIO/ConfigDumpFileIO.cs
@@ -29,14 +29,14 @@ namespace ConfigDumpFileIO
             else if(operationType.Equals("write"))
             {
                 outputFile?.WriteLine(stringToWrite);
-                output.Append("true");
+                output.Append(outputFile != null ? "true" : "false");
                 return;
             }
             else if(operationType.Equals("close"))
             {
+                output.Append(outputFile != null ? "true" : "false");
                 outputFile?.Close();
                 outputFile = null;
-                output.Append("true");
                 return;
             }
 

--- a/ConfigDumpFileIO/ConfigDumpFileIO.cs
+++ b/ConfigDumpFileIO/ConfigDumpFileIO.cs
@@ -21,19 +21,21 @@ namespace ConfigDumpFileIO
             {
                 string assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 string filePath = Path.Combine(assemblyFolder, stringToWrite);
+                outputFile?.Close();
                 outputFile = new StreamWriter(filePath);
                 output.Append("true");
                 return;
             }
             else if(operationType.Equals("write"))
             {
-                outputFile.WriteLine(stringToWrite);
+                outputFile?.WriteLine(stringToWrite);
                 output.Append("true");
                 return;
             }
             else if(operationType.Equals("close"))
             {
-                outputFile.Close();
+                outputFile?.Close();
+                outputFile = null;
                 output.Append("true");
                 return;
             }

--- a/ConfigDumpFileIO_x64/ConfigDumpFileIO_x64.cs
+++ b/ConfigDumpFileIO_x64/ConfigDumpFileIO_x64.cs
@@ -21,19 +21,21 @@ namespace ConfigDumpFileIO_x64
             {
                 string assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 string filePath = Path.Combine(assemblyFolder, stringToWrite);
+                outputFile?.Close();
                 outputFile = new StreamWriter(filePath);
                 output.Append("true");
                 return;
             }
             else if (operationType.Equals("write"))
             {
-                outputFile.WriteLine(stringToWrite);
+                outputFile?.WriteLine(stringToWrite);
                 output.Append("true");
                 return;
             }
             else if (operationType.Equals("close"))
             {
-                outputFile.Close();
+                outputFile?.Close();
+                outputFile = null;
                 output.Append("true");
                 return;
             }


### PR DESCRIPTION
Would crash if you try to open a file that is already open.
Would crash if you try to close a file while you never opened one.
Would crash if you try to write to a file but never opened one.